### PR TITLE
feature: Add WAN status notification script for RouterOS

### DIFF
--- a/networking/routeros/wan_notification.rsc
+++ b/networking/routeros/wan_notification.rsc
@@ -4,7 +4,7 @@
 :local wan2 "lte1";
 :local webhookURL "";
 
-# --- Logic for WAN1 (ether1) ---
+# --- Logic for WAN1 ---
 :local newStatus1;
 :if ([/ping count=5 interface=$wan1 address=$host interval=1s] = 0) do={
     :set newStatus1 "down";
@@ -12,7 +12,7 @@
     :set newStatus1 "up";
 }
 
-# --- Logic for WAN2 (lte1) ---
+# --- Logic for WAN2 ---
 :local newStatus2;
 :if ([/ping count=5 interface=$wan2 address=$host interval=1s] = 0) do={
     :set newStatus2 "down";
@@ -23,7 +23,7 @@
 # Always send a single notification with the current status of both interfaces
 :log info "WAN $wan1 is $newStatus1, WAN $wan2 is $newStatus2. Sending notification.";
 # Use the :serialize function to create a valid JSON string
-:local jsonData [:serialize to=json {"ether1_status"=$newStatus1; "lte1_status"=$newStatus2}];
+:local jsonData [:serialize to=json {"wan1_status"=$newStatus1; "wan2_status"=$newStatus2}];
 # Build the HTTP header string separately
 :local httpHeader "Content-Type:application/json";
 # Pass the variables enclosed in quotes to ensure the parser treats them as single arguments

--- a/networking/routeros/wan_notification.rsc
+++ b/networking/routeros/wan_notification.rsc
@@ -24,12 +24,20 @@
 :log info "WAN $wan1 is $newStatus1, WAN $wan2 is $newStatus2. Sending notification.";
 # Use the :serialize function to create a valid JSON string
 :local jsonData [:serialize to=json {"wan1_status"=$newStatus1; "wan2_status"=$newStatus2}];
-# Build the HTTP header string separately
-:local httpHeader "Content-Type:application/json";
 # Skip sending if no webhook URL is configured
 :if ($webhookURL = "") do={
     :log warning "wan_notification: webhookURL is empty; skipping HTTP POST";
     :return;
 }
+# Build the HTTP header string separately
+:local httpHeader "Content-Type: application/json";
 # Pass the variables enclosed in quotes to ensure the parser treats them as single arguments
-/tool fetch url="$webhookURL" http-data="$jsonData" http-header-field="$httpHeader" http-method=post;
+:do {
+    /tool fetch url="$webhookURL" \
+        http-data="$jsonData" \
+        http-header-field="$httpHeader" \
+        http-method=post \
+        output=none \
+} on-error={
+    :log warning "wan_notification: HTTP POST failed for $webhookURL";
+}

--- a/networking/routeros/wan_notification.rsc
+++ b/networking/routeros/wan_notification.rsc
@@ -1,11 +1,11 @@
 # --- Variable Definitions ---
-:local host "1.1.1.1";
-:local wan1 "ether1";
-:local wan2 "lte1";
-:local webhookURL "";
+:local host "1.1.1.1"; # The IP address to ping for connectivity checks (e.g., a reliable public DNS server like Cloudflare's 1.1.1.1)
+:local wan1 "ether1"; # Name of the first WAN interface to monitor
+:local wan2 "lte1"; # Name of the second WAN interface to monitor
+:local webhookURL ""; # The URL of the webhook to which status notifications will be sent
 
 # --- Logic for WAN1 ---
-:local newStatus1;
+:local newStatus1; # Local variable to store the current status of the first WAN interface
 :if ([/ping count=5 interface=$wan1 address=$host interval=1s] = 0) do={
     :set newStatus1 "down";
 } else={
@@ -13,7 +13,7 @@
 }
 
 # --- Logic for WAN2 ---
-:local newStatus2;
+:local newStatus2; # Local variable to store the current status of the second WAN interface
 :if ([/ping count=5 interface=$wan2 address=$host interval=1s] = 0) do={
     :set newStatus2 "down";
 } else={

--- a/networking/routeros/wan_notification.rsc
+++ b/networking/routeros/wan_notification.rsc
@@ -26,5 +26,10 @@
 :local jsonData [:serialize to=json {"wan1_status"=$newStatus1; "wan2_status"=$newStatus2}];
 # Build the HTTP header string separately
 :local httpHeader "Content-Type:application/json";
+# Skip sending if no webhook URL is configured
+:if ($webhookURL = "") do={
+    :log warning "wan_notification: webhookURL is empty; skipping HTTP POST";
+    :return;
+}
 # Pass the variables enclosed in quotes to ensure the parser treats them as single arguments
 /tool fetch url="$webhookURL" http-data="$jsonData" http-header-field="$httpHeader" http-method=post;

--- a/networking/routeros/wan_notification.rsc
+++ b/networking/routeros/wan_notification.rsc
@@ -5,20 +5,20 @@
 :local webhookURL ""; # The URL of the webhook to which status notifications will be sent
 
 # --- Logic for WAN1 ---
-:local newStatus1; # Local variable to store the current status of the first WAN interface
-:if ([/ping count=5 interface=$wan1 address=$host interval=1s] = 0) do={
-    :set newStatus1 "down";
-} else={
-    :set newStatus1 "up";
-}
+:local newStatus1 "down"; # default to down; only promote on positive replies
+:do {
+    :if (([/ping address=$host interface=$wan1 count=5 interval=1s]) > 0) do={
+        :set newStatus1 "up";
+    }
+} on-error={}
 
 # --- Logic for WAN2 ---
-:local newStatus2; # Local variable to store the current status of the second WAN interface
-:if ([/ping count=5 interface=$wan2 address=$host interval=1s] = 0) do={
-    :set newStatus2 "down";
-} else={
-    :set newStatus2 "up";
-}
+:local newStatus2 "down"; # default to down; only promote on positive replies
+:do {
+    :if (([/ping address=$host interface=$wan2 count=5 interval=1s]) > 0) do={
+        :set newStatus2 "up";
+    }
+} on-error={}
 
 # Always send a single notification with the current status of both interfaces
 :log info "WAN $wan1 is $newStatus1, WAN $wan2 is $newStatus2. Sending notification.";

--- a/networking/routeros/wan_notification.rsc
+++ b/networking/routeros/wan_notification.rsc
@@ -1,0 +1,30 @@
+# --- Variable Definitions ---
+:local host "1.1.1.1";
+:local wan1 "ether1";
+:local wan2 "lte1";
+:local webhookURL "";
+
+# --- Logic for WAN1 (ether1) ---
+:local newStatus1;
+:if ([/ping count=5 interface=$wan1 address=$host interval=1s] = 0) do={
+    :set newStatus1 "down";
+} else={
+    :set newStatus1 "up";
+}
+
+# --- Logic for WAN2 (lte1) ---
+:local newStatus2;
+:if ([/ping count=5 interface=$wan2 address=$host interval=1s] = 0) do={
+    :set newStatus2 "down";
+} else={
+    :set newStatus2 "up";
+}
+
+# Always send a single notification with the current status of both interfaces
+:log info "WAN $wan1 is $newStatus1, WAN $wan2 is $newStatus2. Sending notification.";
+# Use the :serialize function to create a valid JSON string
+:local jsonData [:serialize to=json {"ether1_status"=$newStatus1; "lte1_status"=$newStatus2}];
+# Build the HTTP header string separately
+:local httpHeader "Content-Type:application/json";
+# Pass the variables enclosed in quotes to ensure the parser treats them as single arguments
+/tool fetch url="$webhookURL" http-data="$jsonData" http-header-field="$httpHeader" http-method=post;


### PR DESCRIPTION
This PR adds a script for WAN status notifications for MikroTik routers using RouterOS. This is particularly useful for dual-wan environments. This is tested on hAP ax lite LTE6 with ether1 and lte1 as the WAN interfaces. The statuses are sent to Home Assistant where they are stored on binary sensors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Introduces a RouterOS script that checks connectivity on two WAN interfaces and determines their up/down status.
  * Sends a JSON webhook with the current status of each WAN, enabling external monitoring/alerting.
  * Logs a combined status message for quick visibility in system logs.
  * Configurable target host, WAN interfaces, and webhook URL.
  * Uses standard HTTP POST with JSON Content-Type for broad integration compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->